### PR TITLE
Nuklear GUI font loading and 2D primitives

### DIFF
--- a/src/dagon/core/event.d
+++ b/src/dagon/core/event.d
@@ -245,21 +245,22 @@ class EventManager
 
                 case SDL_TEXTINPUT:
                     e = Event(EventType.TextInput);
-                    if ((event.text.text[0] & 0x80) == 0)
+                    char[] input = event.text.text;
+                    if ((input[0] & 0x80) == 0)
                     {
-                        e.unicode = *cast(ubyte*)(event.text.text);
+                        e.unicode = input[0];
                     }
-                    else if ((event.text.text[0] & 0xE0) == 0xC0)
+                    else if ((input[0] & 0xE0) == 0xC0)
                     {
-                        e.unicode = *cast(ushort*)(event.text.text);
+                        e.unicode = ((input[0] & 0x1F) << 6) | (input[1] & 0x3F);
                     }
-                    else if ((event.text.text[0] & 0xF0) == 0xE0)
+                    else if ((input[0] & 0xF0) == 0xE0)
                     {
-                        e.unicode = event.text.text[0] + event.text.text[1] >> 8 + event.text.text[2] >> 16;
+                        e.unicode = ((input[0] & 0x0F) << 12) | ((input[1] & 0x3F) << 6) | (input[2] & 0x3F);
                     }
-                    else if ((event.text.text[0] & 0xF8) == 0xF0)
+                    else if ((input[0] & 0xF8) == 0xF0)
                     {
-                        e.unicode = *cast(uint*)(event.text.text);
+                        e.unicode = (((input[0] & 0x0F) << 18) | ((input[1] & 0x3F) << 12) | ((input[2] & 0x3F) << 6) | (input[3] & 0x3F));
                     }
                     addEvent(e);
                     break;

--- a/src/dagon/graphics/texture.d
+++ b/src/dagon/graphics/texture.d
@@ -103,6 +103,11 @@ class Texture: Owner
         glTexImage2D(GL_TEXTURE_2D, 0, intFormat, width, height, 0, format, type, cast(void*)img.data.ptr);
 
         useMipmapFiltering = genMipmaps;
+        if (useMipmapFiltering)
+        {
+            glGenerateMipmap(GL_TEXTURE_2D);
+            mipmapGenerated = true;
+        }
 
         glBindTexture(GL_TEXTURE_2D, 0);
     }

--- a/src/dagon/graphics/texture.d
+++ b/src/dagon/graphics/texture.d
@@ -175,20 +175,6 @@ class Texture: Owner
             glDeleteTextures(1, &tex);
     }
 
-    nk_image toNuklearImage()
-    {
-        nk_image img;
-        img.handle.id = cast(int)tex;
-        img.w = cast(short)width;
-        img.h = cast(short)height;
-        img.region[2] = cast(short)width;
-        img.region[3] = cast(short)height;
-        return img;
-    }
-
-    // Commented out due to bug in DMD
-    //alias toNuklearImage this; // allow implicit convertion to nk_image
-
     ~this()
     {
         release();

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -49,6 +49,7 @@ alias nk_cursor NkCursor;
 alias nk_font NkFont;
 alias nk_flags NkFlags;
 alias nk_size NkSize;
+alias nk_image NkImage;
 
 private extern(C) void clipboardPaste(nk_handle usr, nk_text_edit* edit)
 {
@@ -343,6 +344,8 @@ class NuklearGUI : Owner, Drawable
     }
 
     static const(nk_rune[]) fontDefaultGlyphRanges = [ 0x0020, 0x00FF, 0 ];
+    static const(nk_rune[]) fontLatinExtentedAGlyphRanges = [ 0x0020, 0x017F, 0 ];
+    static const(nk_rune[]) fontLatinExtentedBGlyphRanges = [ 0x0020, 0x024F, 0 ];
     static const(nk_rune[]) fontChineseGlyphRanges = [ 0x0020, 0x00FF, 0x3000, 0x30FF, 0x31F0, 0x31FF, 0xFF00, 0xFFEF, 0x4E00, 0x9FAF, 0 ];
     static const(nk_rune[]) fontCyrillicGlyphRanges = [ 0x0020, 0x00FF,  0x0400, 0x052F, 0x2DE0, 0x2DFF, 0xA640, 0xA69F, 0 ];
     static const(nk_rune[]) fontKoreanGlyphRanges = [ 0x0020, 0x00FF, 0x3131, 0x3163,  0xAC00, 0xD79D, 0 ];

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -127,9 +127,9 @@ class NuklearGUI : Owner, Drawable
     string vs = import("Nuklear.vs");
     string fs = import("Nuklear.fs");
 
-    EventManager* eventManager; // Needed for mouse position
+    EventManager eventManager; // Needed for mouse position
 
-    this(EventManager* em, Owner o)
+    this(EventManager em, Owner o)
     {
         super(o);
 

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -1858,4 +1858,10 @@ class NuklearGUI : Owner, Drawable
         if(ctx.current)
             nk_draw_text(&ctx.current.buffer, rect, txt, len, font, bg, fg);
     }
+
+    void pushScissor(nk_rect rect)
+    {
+        if(ctx.current)
+            nk_push_scissor(&ctx.current.buffer, rect);
+    }
 }

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -357,6 +357,18 @@ class NuklearGUI : Owner, Drawable
         return lastFont = nk_font_atlas_add_from_memory(&atlas, font.buffer.ptr, font.buffer.length, height, &cfg);
     }
 
+    float textWidth(const(char)* txt, int len)
+    {
+        const(nk_user_font) *f = ctx.style.font;
+        return f.width(cast(nk_handle)f.userdata, f.height, txt, len);
+    }
+
+    float textWidth(NkFont* font, const(char)* txt, int len)
+    {
+        const(nk_user_font) *f = &font.handle;
+        return f.width(cast(nk_handle)f.userdata, f.height, txt, len);
+    }
+
     void inputKey(nk_keys key, int down)
     {
         auto e = NuklearEvent(NuklearEventType.Key);

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -39,6 +39,17 @@ import dagon.core.keycodes;
 import dagon.graphics.shaderloader;
 import dagon.resource.fontasset;
 
+alias nk_color NkColor;
+alias nk_colorf NkColorf;
+alias nk_rect NkRect;
+alias nk_rect NkRecti;
+alias nk_vec2 NkVec2;
+alias nk_vec2i NkVec2i;
+alias nk_cursor NkCursor;
+alias nk_font NkFont;
+alias nk_flags NkFlags;
+alias nk_size NkSize;
+
 private extern(C) void clipboardPaste(nk_handle usr, nk_text_edit* edit)
 {
     char* text = SDL_GetClipboardText();
@@ -88,21 +99,11 @@ struct NuklearEvent
 
 class NuklearGUI : Owner, Drawable
 {
-    alias nk_color Color;
-    alias nk_colorf Colorf;
-    alias nk_rect Rect;
-    alias nk_rect Recti;
-    alias nk_vec2 Vec2;
-    alias nk_vec2i Vec2i;
-    alias nk_cursor Cursor;
-    alias nk_font Font;
-
     NuklearEvent[10] events;
     int eventsCount = 0;
 
     nk_context ctx;
     nk_font_atlas atlas;
-    nk_font_atlas atlasDefault;
     nk_buffer cmds;
     nk_draw_null_texture nullTexture;
     nk_font* lastFont;

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -39,17 +39,21 @@ import dagon.core.keycodes;
 import dagon.graphics.shaderloader;
 import dagon.resource.fontasset;
 
-alias nk_color NkColor;
-alias nk_colorf NkColorf;
-alias nk_rect NkRect;
-alias nk_rect NkRecti;
-alias nk_vec2 NkVec2;
-alias nk_vec2i NkVec2i;
-alias nk_cursor NkCursor;
-alias nk_font NkFont;
-alias nk_flags NkFlags;
-alias nk_size NkSize;
-alias nk_image NkImage;
+alias nk_color NKColor;
+alias nk_colorf NKColorf;
+alias nk_rect NKRect;
+alias nk_rect NKRecti;
+alias nk_vec2 NKVec2;
+alias nk_vec2i NKVec2i;
+alias nk_cursor NKCursor;
+alias nk_font NKFont;
+alias nk_flags NKFlags;
+alias nk_size NKSize;
+alias nk_image NKImage;
+alias nk_rune NKRune;
+alias nk_handle NKHandle;
+alias nk_window NKWindow;
+alias nk_panel NKPanel;
 
 private extern(C) void clipboardPaste(nk_handle usr, nk_text_edit* edit)
 {
@@ -343,14 +347,14 @@ class NuklearGUI : Owner, Drawable
         glDisable(GL_SCISSOR_TEST);
     }
 
-    static const(nk_rune[]) fontDefaultGlyphRanges = [ 0x0020, 0x00FF, 0 ];
-    static const(nk_rune[]) fontLatinExtentedAGlyphRanges = [ 0x0020, 0x017F, 0 ];
-    static const(nk_rune[]) fontLatinExtentedBGlyphRanges = [ 0x0020, 0x024F, 0 ];
-    static const(nk_rune[]) fontChineseGlyphRanges = [ 0x0020, 0x00FF, 0x3000, 0x30FF, 0x31F0, 0x31FF, 0xFF00, 0xFFEF, 0x4E00, 0x9FAF, 0 ];
-    static const(nk_rune[]) fontCyrillicGlyphRanges = [ 0x0020, 0x00FF,  0x0400, 0x052F, 0x2DE0, 0x2DFF, 0xA640, 0xA69F, 0 ];
-    static const(nk_rune[]) fontKoreanGlyphRanges = [ 0x0020, 0x00FF, 0x3131, 0x3163,  0xAC00, 0xD79D, 0 ];
+    static const(NKRune[]) fontDefaultGlyphRanges = [ 0x0020, 0x00FF, 0 ];
+    static const(NKRune[]) fontLatinExtendedAGlyphRanges = [ 0x0020, 0x017F, 0 ];
+    static const(NKRune[]) fontLatinExtendedBGlyphRanges = [ 0x0020, 0x024F, 0 ];
+    static const(NKRune[]) fontChineseGlyphRanges = [ 0x0020, 0x00FF, 0x3000, 0x30FF, 0x31F0, 0x31FF, 0xFF00, 0xFFEF, 0x4E00, 0x9FAF, 0 ];
+    static const(NKRune[]) fontCyrillicGlyphRanges = [ 0x0020, 0x00FF,  0x0400, 0x052F, 0x2DE0, 0x2DFF, 0xA640, 0xA69F, 0 ];
+    static const(NKRune[]) fontKoreanGlyphRanges = [ 0x0020, 0x00FF, 0x3131, 0x3163,  0xAC00, 0xD79D, 0 ];
 
-    nk_font* addFont(FontAsset font, float height = 13, const(nk_rune[]) range = fontDefaultGlyphRanges)
+    NKFont* addFont(FontAsset font, float height = 13, const(NKRune[]) range = fontDefaultGlyphRanges)
     {
         nk_font_config cfg = nk_font_config_(0);
         cfg.range = range.ptr;
@@ -363,7 +367,7 @@ class NuklearGUI : Owner, Drawable
         return f.width(cast(nk_handle)f.userdata, f.height, txt, len);
     }
 
-    float textWidth(NkFont* font, const(char)* txt, int len)
+    float textWidth(NKFont* font, const(char)* txt, int len)
     {
         const(nk_user_font) *f = &font.handle;
         return f.width(cast(nk_handle)f.userdata, f.height, txt, len);
@@ -433,17 +437,12 @@ class NuklearGUI : Owner, Drawable
             events[eventsCount++] = e;
     }
 
-    void setUserData(nk_handle handle)
-    {
-        nk_set_user_data(&ctx, handle);
-    }
-
-    int begin(const(char)* title, nk_rect bounds, nk_flags flags)
+    int begin(const(char)* title, NKRect bounds, NKFlags flags)
     {
         return nk_begin(&ctx, title, bounds, flags);
     }
 
-    int beginTitled(const(char)* name, const(char)* title, nk_rect bounds, nk_flags flags)
+    int beginTitled(const(char)* name, const(char)* title, NKRect bounds, NKFlags flags)
     {
         return nk_begin_titled(&ctx, name, title, bounds, flags);
     }
@@ -455,7 +454,7 @@ class NuklearGUI : Owner, Drawable
 
     nk_style_window oldWindowStyle;
 
-    int canvasBegin(const(char)* title, nk_rect bounds, nk_color background)
+    int canvasBegin(const(char)* title, NKRect bounds, NKColor background = NKColor(255,255,255,255))
     {
         oldWindowStyle = ctx.style.window;
 
@@ -478,32 +477,32 @@ class NuklearGUI : Owner, Drawable
         ctx.style.window = oldWindowStyle;
     }
 
-    nk_window* windowFind(const(char)* name)
+    NKWindow* windowFind(const(char)* name)
     {
         return nk_window_find(&ctx, name);
     }
 
-    nk_panel* windowGetPanel()
+    NKPanel* windowGetPanel()
     {
         return nk_window_get_panel(&ctx);
     }
 
-    nk_rect windowGetContentRegion()
+    NKRect windowGetContentRegion()
     {
         return nk_window_get_content_region(&ctx);
     }
 
-    nk_vec2 windowGetContentRegionMin()
+    NKVec2 windowGetContentRegionMin()
     {
         return nk_window_get_content_region_min(&ctx);
     }
 
-    nk_vec2 windowGetContentRegionMax()
+    NKVec2 windowGetContentRegionMax()
     {
         return nk_window_get_content_region_max(&ctx);
     }
 
-    nk_vec2 windowGetContentRegionSize()
+    NKVec2 windowGetContentRegionSize()
     {
         return nk_window_get_content_region_size(&ctx);
     }
@@ -548,17 +547,17 @@ class NuklearGUI : Owner, Drawable
         return nk_item_is_any_active(&ctx);
     }
 
-    void windowSetBounds(const(char)* name, nk_rect bounds)
+    void windowSetBounds(const(char)* name, NKRect bounds)
     {
         nk_window_set_bounds(&ctx, name, bounds);
     }
 
-    void windowSetPosition(const(char)* name, nk_vec2 pos)
+    void windowSetPosition(const(char)* name, NKVec2 pos)
     {
         nk_window_set_position(&ctx, name, pos);
     }
 
-    void windowSetSize(const(char)* name, nk_vec2 size)
+    void windowSetSize(const(char)* name, NKVec2 size)
     {
         nk_window_set_size(&ctx, name, size);
     }
@@ -603,7 +602,7 @@ class NuklearGUI : Owner, Drawable
         nk_layout_reset_min_row_height(&ctx);
     }
 
-    nk_rect layoutWidgetBounds()
+    NKRect layoutWidgetBounds()
     {
         return nk_layout_widget_bounds(&ctx);
     }
@@ -673,7 +672,7 @@ class NuklearGUI : Owner, Drawable
         nk_layout_space_begin(&ctx, foramt, height, widget_count);
     }
 
-    void layoutSpacePush(nk_rect bounds)
+    void layoutSpacePush(NKRect bounds)
     {
         nk_layout_space_push(&ctx, bounds);
     }
@@ -683,37 +682,37 @@ class NuklearGUI : Owner, Drawable
         nk_layout_space_end(&ctx);
     }
 
-    nk_rect layoutSpaceBounds()
+    NKRect layoutSpaceBounds()
     {
         return nk_layout_space_bounds(&ctx);
     }
 
-    nk_vec2 layoutSpaceToScreen(nk_vec2 a)
+    NKVec2 layoutSpaceToScreen(NKVec2 a)
     {
         return nk_layout_space_to_screen(&ctx, a);
     }
 
-    nk_vec2 layoutSpaceToLocal(nk_vec2 a)
+    NKVec2 layoutSpaceToLocal(NKVec2 a)
     {
         return nk_layout_space_to_local(&ctx, a);
     }
 
-    nk_rect layoutSpaceRectToScreen(nk_rect a)
+    NKRect layoutSpaceRectToScreen(NKRect a)
     {
         return nk_layout_space_rect_to_screen(&ctx, a);
     }
 
-    nk_rect layoutSpaceRectToLocal(nk_rect a)
+    NKRect layoutSpaceRectToLocal(NKRect a)
     {
         return nk_layout_space_rect_to_local(&ctx, a);
     }
 
-    int groupBegin(const(char)* title, nk_flags flags)
+    int groupBegin(const(char)* title, NKFlags flags)
     {
         return nk_group_begin(&ctx, title, flags);
     }
 
-    int groupBeginTitled(const(char)* name, const(char)* title, nk_flags flags)
+    int groupBeginTitled(const(char)* name, const(char)* title, NKFlags flags)
     {
         return nk_group_begin_titled(&ctx, name, title, flags);
     }
@@ -723,12 +722,12 @@ class NuklearGUI : Owner, Drawable
         nk_group_end(&ctx);
     }
 
-    int groupScrolledOffsetBegin(nk_uint* x_offset, nk_uint* y_offset, const(char)* title, nk_flags flags)
+    int groupScrolledOffsetBegin(nk_uint* x_offset, nk_uint* y_offset, const(char)* title, NKFlags flags)
     {
         return nk_group_scrolled_offset_begin(&ctx, x_offset, y_offset, title, flags);
     }
 
-    int groupScrolledBegin(nk_scroll* off, const(char)* title, nk_flags flags)
+    int groupScrolledBegin(nk_scroll* off, const(char)* title, NKFlags flags)
     {
         return nk_group_scrolled_begin(&ctx, off, title, flags);
     }
@@ -758,7 +757,7 @@ class NuklearGUI : Owner, Drawable
         return nk_tree_state_push(&ctx, type, title, state);
     }
 
-    int treeStateImagePush(nk_tree_type type, nk_image image, const(char)* title, nk_collapse_states* state)
+    int treeStateImagePush(nk_tree_type type, NKImage image, const(char)* title, nk_collapse_states* state)
     {
         return nk_tree_state_image_push(&ctx, type, image, title, state);
     }
@@ -778,12 +777,12 @@ class NuklearGUI : Owner, Drawable
         return nk_tree_element_push_hashed(&ctx, type, title, state, selected, null, 0, id);
     }
 
-    auto treeElementImagePush(size_t line = __LINE__)(nk_tree_type type, nk_image img, const(char) *title, nk_collapse_states state)
+    auto treeElementImagePush(size_t line = __LINE__)(nk_tree_type type, NKImage img, const(char) *title, nk_collapse_states state)
     {
         return nk_tree_image_push_hashed(&ctx, type, img, title, state, null, 0, line);
     }
 
-    auto treeElementImagePushId(nk_tree_type type, nk_image img, const(char) *title, nk_collapse_states state, int id)
+    auto treeElementImagePushId(nk_tree_type type, NKImage img, const(char) *title, nk_collapse_states state, int id)
     {
         return nk_tree_image_push_hashed(&ctx, type, img, title, state, null, 0, id);
     }
@@ -793,22 +792,22 @@ class NuklearGUI : Owner, Drawable
         nk_tree_element_pop(&ctx);
     }
 
-    int listViewBegin(nk_list_view* out_, const(char)* id, nk_flags flags, int row_height, int row_count)
+    int listViewBegin(nk_list_view* out_, const(char)* id, NKFlags flags, int row_height, int row_count)
     {
         return nk_list_view_begin(&ctx, out_, id, flags, row_height, row_count);
     }
 
-    nk_rect widgetBounds()
+    NKRect widgetBounds()
     {
         return nk_widget_bounds(&ctx);
     }
 
-    nk_vec2 widgetPosition()
+    NKVec2 widgetPosition()
     {
         return nk_widget_position(&ctx);
     }
 
-    nk_vec2 widgetSize()
+    NKVec2 widgetSize()
     {
         return nk_widget_size(&ctx);
     }
@@ -843,12 +842,12 @@ class NuklearGUI : Owner, Drawable
         nk_spacing(&ctx, cols);
     }
 
-    void text(const(char)* txt, int len, nk_flags flags)
+    void text(const(char)* txt, int len, NKFlags flags)
     {
         nk_text(&ctx, txt, len, flags);
     }
 
-    void textColored(const(char)* txt, int len, nk_flags flags, nk_color color)
+    void textColored(const(char)* txt, int len, NKFlags flags, NKColor color)
     {
         nk_text_colored(&ctx, txt, len, flags, color);
     }
@@ -858,17 +857,17 @@ class NuklearGUI : Owner, Drawable
         nk_text_wrap(&ctx, txt, len);
     }
 
-    void textWrapColored(const(char)* txt, int len, nk_color color)
+    void textWrapColored(const(char)* txt, int len, NKColor color)
     {
         nk_text_wrap_colored(&ctx, txt, len, color);
     }
 
-    void label(const(char)* txt, nk_flags align__)
+    void label(const(char)* txt, NKFlags align__)
     {
         nk_label(&ctx, txt, align__);
     }
 
-    void labelColored(const(char)* txt, nk_flags align__, nk_color color)
+    void labelColored(const(char)* txt, NKFlags align__, NKColor color)
     {
         nk_label_colored(&ctx, txt, align__, color);
     }
@@ -878,29 +877,29 @@ class NuklearGUI : Owner, Drawable
         nk_label_wrap(&ctx, txt);
     }
 
-    void labelColoredWrap(const(char)* txt, nk_color color)
+    void labelColoredWrap(const(char)* txt, NKColor color)
     {
         nk_label_colored_wrap(&ctx, txt, color);
     }
 
-    void image(nk_image img)
+    void image(NKImage img)
     {
         nk_image_(&ctx, img);
     }
 
-    void imageColor(nk_image img, nk_color color)
+    void imageColor(NKImage img, NKColor color)
     {
         nk_image_color(&ctx, img, color);
     }
 
-    void labelf(nk_flags align_, const(char)* format, ...)
+    void labelf(NKFlags align_, const(char)* format, ...)
     {
         va_list args;
         va_start(args, format);
         nk_labelfv(&ctx, align_, format, args);
     }
 
-    void labelfColored(nk_flags align_, nk_color color, const(char)* format, ...)
+    void labelfColored(NKFlags align_, NKColor color, const(char)* format, ...)
     {
         va_list args;
         va_start(args, format);
@@ -914,7 +913,7 @@ class NuklearGUI : Owner, Drawable
         nk_labelf_wrap(&ctx, format, args);
     }
 
-    void labelfColoredWrap(nk_color color, const(char)* format, ...)
+    void labelfColoredWrap(NKColor color, const(char)* format, ...)
     {
         va_list args;
         va_start(args, format);
@@ -941,17 +940,17 @@ class NuklearGUI : Owner, Drawable
         nk_value_float(&ctx, prefix, value);
     }
 
-    void valueColorByte(const(char)* prefix, nk_color value)
+    void valueColorByte(const(char)* prefix, NKColor value)
     {
         nk_value_color_byte(&ctx, prefix, value);
     }
 
-    void valueColorFloat(const(char)* prefix, nk_color value)
+    void valueColorFloat(const(char)* prefix, NKColor value)
     {
         nk_value_color_float(&ctx, prefix, value);
     }
 
-    void valueColorHex(const(char)* prefix, nk_color value)
+    void valueColorHex(const(char)* prefix, NKColor value)
     {
         nk_value_color_hex(&ctx, prefix, value);
     }
@@ -966,7 +965,7 @@ class NuklearGUI : Owner, Drawable
         return nk_button_label(&ctx, title);
     }
 
-    int buttonColor(nk_color color)
+    int buttonColor(NKColor color)
     {
         return nk_button_color(&ctx,  color);
     }
@@ -976,27 +975,27 @@ class NuklearGUI : Owner, Drawable
         return nk_button_symbol(&ctx, type);
     }
 
-    int buttonImage(nk_image img)
+    int buttonImage(NKImage img)
     {
         return nk_button_image(&ctx, img);
     }
 
-    int buttonSymbolLabel(nk_symbol_type type, const(char)* label, nk_flags text_alignment)
+    int buttonSymbolLabel(nk_symbol_type type, const(char)* label, NKFlags text_alignment)
     {
         return nk_button_symbol_label(&ctx, type, label, text_alignment);
     }
 
-    int buttonSymbolText(nk_symbol_type type, const(char)* txt, int len, nk_flags align_ment)
+    int buttonSymbolText(nk_symbol_type type, const(char)* txt, int len, NKFlags align_ment)
     {
         return nk_button_symbol_text(&ctx, type, txt, len, align_ment);
     }
 
-    int buttonImageLabel(nk_image img, const(char)* txt, nk_flags text_alignment)
+    int buttonImageLabel(NKImage img, const(char)* txt, NKFlags text_alignment)
     {
         return nk_button_image_label(&ctx, img, txt, text_alignment);
     }
 
-    int buttonImageText(nk_image img, const(char)* txt, int len, nk_flags align_ment)
+    int buttonImageText(NKImage img, const(char)* txt, int len, NKFlags align_ment)
     {
         return nk_button_image_text(&ctx, img, txt, len, align_ment);
     }
@@ -1016,27 +1015,27 @@ class NuklearGUI : Owner, Drawable
         return nk_button_symbol_styled(&ctx, style, type);
     }
 
-    int buttonImageStyled(const(nk_style_button)* style, nk_image img)
+    int buttonImageStyled(const(nk_style_button)* style, NKImage img)
     {
         return nk_button_image_styled(&ctx, style, img);
     }
 
-    int buttonSymbolTextStyled(const(nk_style_button)* style, nk_symbol_type type, const(char)* txt, int len, nk_flags align_ment)
+    int buttonSymbolTextStyled(const(nk_style_button)* style, nk_symbol_type type, const(char)* txt, int len, NKFlags align_ment)
     {
         return nk_button_symbol_text_styled(&ctx, style, type, txt, len, align_ment);
     }
 
-    int buttonSymbolLabelStyled(const(nk_style_button)* style, nk_symbol_type symbol, const(char)* title, nk_flags align_)
+    int buttonSymbolLabelStyled(const(nk_style_button)* style, nk_symbol_type symbol, const(char)* title, NKFlags align_)
     {
         return nk_button_symbol_label_styled(&ctx, style, symbol, title, align_);
     }
 
-    int buttonImageLabelStyled(const(nk_style_button)* style, nk_image img, const(char)* label, nk_flags text_alignment)
+    int buttonImageLabelStyled(const(nk_style_button)* style, NKImage img, const(char)* label, NKFlags text_alignment)
     {
         return nk_button_image_label_styled(&ctx, style, img, label, text_alignment);
     }
 
-    int buttonImageTextStyled(const(nk_style_button)* style, nk_image img, const(char)* txt, int len, nk_flags align_ment)
+    int buttonImageTextStyled(const(nk_style_button)* style, NKImage img, const(char)* txt, int len, NKFlags align_ment)
     {
         return nk_button_image_text_styled(&ctx, style, img, txt, len, align_ment);
     }
@@ -1116,62 +1115,62 @@ class NuklearGUI : Owner, Drawable
         return nk_option_text(&ctx, txt, len, active);
     }
 
-    int selectableLabel(const(char)* label, nk_flags align_, int* value)
+    int selectableLabel(const(char)* label, NKFlags align_, int* value)
     {
         return nk_selectable_label(&ctx, label, align_, value);
     }
 
-    int selectableText(const(char)* txt, int len, nk_flags align_, int* value)
+    int selectableText(const(char)* txt, int len, NKFlags align_, int* value)
     {
         return nk_selectable_text(&ctx, txt, len, align_, value);
     }
 
-    int selectableImageLabel(nk_image img, const(char)* label, nk_flags align_, int* value)
+    int selectableImageLabel(NKImage img, const(char)* label, NKFlags align_, int* value)
     {
         return nk_selectable_image_label(&ctx, img, label, align_, value);
     }
 
-    int selectableImageText(nk_image img, const(char)* text, int len, nk_flags align_, int* value)
+    int selectableImageText(NKImage img, const(char)* text, int len, NKFlags align_, int* value)
     {
         return nk_selectable_image_text(&ctx, img, text, len, align_, value);
     }
 
-    int selectableSymbolLabel(nk_symbol_type type, const(char)* label, nk_flags align_, int* value)
+    int selectableSymbolLabel(nk_symbol_type type, const(char)* label, NKFlags align_, int* value)
     {
         return nk_selectable_symbol_label(&ctx, type, label, align_, value);
     }
 
-    int selectableSymbolText(nk_symbol_type type, const(char)* txt, int len, nk_flags align_, int* value)
+    int selectableSymbolText(nk_symbol_type type, const(char)* txt, int len, NKFlags align_, int* value)
     {
         return nk_selectable_symbol_text(&ctx, type, txt, len, align_, value);
     }
 
-    int selectLabel(const(char)* label, nk_flags align_, int value)
+    int selectLabel(const(char)* label, NKFlags align_, int value)
     {
         return nk_select_label(&ctx, label, align_, value);
     }
 
-    int selectText(const(char)* txt, int len, nk_flags align_, int value)
+    int selectText(const(char)* txt, int len, NKFlags align_, int value)
     {
         return nk_select_text(&ctx, txt, len, align_, value);
     }
 
-    int selectImageLabel(nk_image img, const(char)* label, nk_flags align_, int value)
+    int selectImageLabel(NKImage img, const(char)* label, NKFlags align_, int value)
     {
         return nk_select_image_label(&ctx, img, label, align_, value);
     }
 
-    int selectImageText(nk_image img, const(char)* txt, int len, nk_flags align_, int value)
+    int selectImageText(NKImage img, const(char)* txt, int len, NKFlags align_, int value)
     {
         return nk_select_image_text(&ctx, img, txt, len, align_, value);
     }
 
-    int selectSymbolLabel(nk_symbol_type type, const(char)* label, nk_flags align_, int value)
+    int selectSymbolLabel(nk_symbol_type type, const(char)* label, NKFlags align_, int value)
     {
         return nk_select_symbol_label(&ctx, type, label, align_, value);
     }
 
-    int selectSymbolText(nk_symbol_type type, const(char)* txt, int len, nk_flags align_, int value)
+    int selectSymbolText(nk_symbol_type type, const(char)* txt, int len, NKFlags align_, int value)
     {
         return nk_select_symbol_text(&ctx, type, txt, len, align_, value);
     }
@@ -1196,17 +1195,17 @@ class NuklearGUI : Owner, Drawable
         return nk_slider_int(&ctx, min, val, max, step);
     }
 
-    int progress(nk_size* cur, nk_size max, int modifyable)
+    int progress(NKSize* cur, NKSize max, int modifyable)
     {
         return nk_progress(&ctx, cur, max, modifyable);
     }
 
-    nk_size prog(nk_size cur, nk_size max, int modifyable)
+    NKSize prog(NKSize cur, NKSize max, int modifyable)
     {
         return nk_prog(&ctx, cur, max, modifyable);
     }
 
-    nk_colorf colorPicker(nk_colorf color, nk_color_format format)
+    NKColorf colorPicker(NKColorf color, nk_color_format format)
     {
         return nk_color_picker(&ctx, color, format);
     }
@@ -1218,7 +1217,7 @@ class NuklearGUI : Owner, Drawable
         return Color4f(tmp.r, tmp.g, tmp.b, tmp.a);
     }
 
-    int colorPick(nk_colorf* color, nk_color_format format)
+    int colorPick(NKColorf* color, nk_color_format format)
     {
         return nk_color_pick(&ctx, color, format);
     }
@@ -1269,22 +1268,22 @@ class NuklearGUI : Owner, Drawable
     alias nk_filter_oct filterOct;
     alias nk_filter_binary filterBinary;
 
-    nk_flags editString(nk_flags flags, char* buffer, int* len, int max, nk_plugin_filter filter = filterDefault)
+    NKFlags editString(NKFlags flags, char* buffer, int* len, int max, nk_plugin_filter filter = filterDefault)
     {
         return nk_edit_string(&ctx, flags, buffer, len, max, filter);
     }
 
-    nk_flags editStringZeroTerminated(nk_flags flags, char* buffer, int max, nk_plugin_filter filter = filterDefault)
+    NKFlags editStringZeroTerminated(NKFlags flags, char* buffer, int max, nk_plugin_filter filter = filterDefault)
     {
         return nk_edit_string_zero_terminated(&ctx, flags, buffer, max, filter);
     }
 
-    nk_flags editBuffer(nk_flags flags, nk_text_edit* edit, nk_plugin_filter filter = filterDefault)
+    NKFlags editBuffer(NKFlags flags, nk_text_edit* edit, nk_plugin_filter filter = filterDefault)
     {
         return nk_edit_buffer(&ctx, flags, edit, filter);
     }
 
-    void editFocus(nk_flags flags)
+    void editFocus(NKFlags flags)
     {
         nk_edit_focus(&ctx, flags);
     }
@@ -1299,7 +1298,7 @@ class NuklearGUI : Owner, Drawable
         return nk_chart_begin(&ctx, type, num, min, max);
     }
 
-    int chartBeginColored(nk_chart_type type, nk_color color, nk_color active, int num, float min, float max)
+    int chartBeginColored(nk_chart_type type, NKColor color, NKColor active, int num, float min, float max)
     {
         return nk_chart_begin_colored(&ctx, type, color, active, num, min, max);
     }
@@ -1309,17 +1308,17 @@ class NuklearGUI : Owner, Drawable
         nk_chart_add_slot(&ctx, type, count, min_value, max_value);
     }
 
-    void chartAddSlotColored(const(nk_chart_type) type, nk_color color, nk_color active, int count, float min_value, float max_value)
+    void chartAddSlotColored(const(nk_chart_type) type, NKColor color, NKColor active, int count, float min_value, float max_value)
     {
         nk_chart_add_slot_colored(&ctx, type, color, active, count, min_value, max_value);
     }
 
-    nk_flags chartPush(float value)
+    NKFlags chartPush(float value)
     {
         return nk_chart_push(&ctx, value);
     }
 
-    nk_flags chartPushSlot(float value, int slot)
+    NKFlags chartPushSlot(float value, int slot)
     {
         return nk_chart_push_slot(&ctx, value, slot);
     }
@@ -1359,7 +1358,7 @@ class NuklearGUI : Owner, Drawable
         }
     }
 
-    int popupBegin(nk_popup_type type, const(char)* title, nk_flags flags, nk_rect bounds)
+    int popupBegin(nk_popup_type type, const(char)* title, NKFlags flags, NKRect bounds)
     {
         return nk_popup_begin(&ctx, type, title, flags, bounds);
     }
@@ -1374,117 +1373,117 @@ class NuklearGUI : Owner, Drawable
         nk_popup_end(&ctx);
     }
 
-    int combo(const(char)** items, int count, int selected, int item_height, nk_vec2 size)
+    int combo(const(char)** items, int count, int selected, int item_height, NKVec2 size)
     {
         return nk_combo(&ctx, items, count, selected, item_height, size);
     }
 
-    int comboSeparator(const(char)* items_separated_by_separator, int separator, int selected, int count, int item_height, nk_vec2 size)
+    int comboSeparator(const(char)* items_separated_by_separator, int separator, int selected, int count, int item_height, NKVec2 size)
     {
         return nk_combo_separator(&ctx, items_separated_by_separator, separator, selected, count, item_height, size);
     }
 
-    int comboString(const(char)* items_separated_by_zeros, int selected, int count, int item_height, nk_vec2 size)
+    int comboString(const(char)* items_separated_by_zeros, int selected, int count, int item_height, NKVec2 size)
     {
         return nk_combo_string(&ctx, items_separated_by_zeros, selected, count, item_height, size);
     }
 
-    /*int comboCallback(void func(void*, int, const(char) **) fn, void *userdata, int selected, int count, int item_height, nk_vec2 size)
+    /*int comboCallback(void func(void*, int, const(char) **) fn, void *userdata, int selected, int count, int item_height, NKVec2 size)
     {
     return nk_combo_callback(&ctx, fn, userdata, selected, count, item_height, size);
     }*/
 
-    void combobox(const(char)** items, int count, int* selected, int item_height, nk_vec2 size)
+    void combobox(const(char)** items, int count, int* selected, int item_height, NKVec2 size)
     {
         nk_combobox(&ctx, items, count, selected, item_height, size);
     }
 
-    void comboboxString(const(char)* items_separated_by_zeros, int* selected, int count, int item_height, nk_vec2 size)
+    void comboboxString(const(char)* items_separated_by_zeros, int* selected, int count, int item_height, NKVec2 size)
     {
         nk_combobox_string(&ctx, items_separated_by_zeros, selected, count, item_height, size);
     }
 
-    void comboboxSeparator(const(char)* items_separated_by_separator, int separator, int* selected, int count, int item_height, nk_vec2 size)
+    void comboboxSeparator(const(char)* items_separated_by_separator, int separator, int* selected, int count, int item_height, NKVec2 size)
     {
         nk_combobox_separator(&ctx, items_separated_by_separator, separator, selected, count, item_height, size);
     }
 
-    /*void comboboxCallback(void function(void*, int, const(char) **), void*, int *selected, int count, int item_height, nk_vec2 size)
+    /*void comboboxCallback(void function(void*, int, const(char) **), void*, int *selected, int count, int item_height, NKVec2 size)
     {
     nk_combobox_callback(&ctx);
     }*/
     
-    int comboBeginText(const(char)* selected, int len, nk_vec2 size)
+    int comboBeginText(const(char)* selected, int len, NKVec2 size)
     {
         return nk_combo_begin_text(&ctx, selected, len, size);
     }
 
-    int comboBeginLabel(const(char)* selected, nk_vec2 size)
+    int comboBeginLabel(const(char)* selected, NKVec2 size)
     {
         return nk_combo_begin_label(&ctx, selected, size);
     }
 
-    int comboBeginColor(nk_color color, nk_vec2 size)
+    int comboBeginColor(NKColor color, NKVec2 size)
     {
         return nk_combo_begin_color(&ctx, color, size);
     }
 
-    int comboBeginSymbol(nk_symbol_type type, nk_vec2 size)
+    int comboBeginSymbol(nk_symbol_type type, NKVec2 size)
     {
         return nk_combo_begin_symbol(&ctx, type, size);
     }
 
-    int comboBeginSymbolLabel(const(char)* selected, nk_symbol_type type, nk_vec2 size)
+    int comboBeginSymbolLabel(const(char)* selected, nk_symbol_type type, NKVec2 size)
     {
         return nk_combo_begin_symbol_label(&ctx, selected, type, size);
     }
 
-    int comboBeginSymbolText(const(char)* selected, int len, nk_symbol_type type, nk_vec2 size)
+    int comboBeginSymbolText(const(char)* selected, int len, nk_symbol_type type, NKVec2 size)
     {
         return nk_combo_begin_symbol_text(&ctx, selected, len, type, size);
     }
 
-    int comboBeginImage(nk_image img, nk_vec2 size)
+    int comboBeginImage(NKImage img, NKVec2 size)
     {
         return nk_combo_begin_image(&ctx, img, size);
     }
 
-    int comboBeginImageLabel(const(char)* selected, nk_image img, nk_vec2 size)
+    int comboBeginImageLabel(const(char)* selected, NKImage img, NKVec2 size)
     {
         return nk_combo_begin_image_label(&ctx, selected, img, size);
     }
 
-    int comboBeginImageText(const(char)* selected, int len, nk_image img, nk_vec2 size)
+    int comboBeginImageText(const(char)* selected, int len, NKImage img, NKVec2 size)
     {
         return nk_combo_begin_image_text(&ctx, selected, len, img, size);
     }
 
-    int comboItemLabel(const(char)* label, nk_flags align_ment)
+    int comboItemLabel(const(char)* label, NKFlags align_ment)
     {
         return nk_combo_item_label(&ctx, label, align_ment);
     }
 
-    int comboItemText(const(char)* txt, int len, nk_flags align_ment)
+    int comboItemText(const(char)* txt, int len, NKFlags align_ment)
     {
         return nk_combo_item_text(&ctx, txt, len, align_ment);
     }
 
-    int comboItemImageLabel(nk_image img, const(char)* label, nk_flags align_ment)
+    int comboItemImageLabel(NKImage img, const(char)* label, NKFlags align_ment)
     {
         return nk_combo_item_image_label(&ctx, img, label, align_ment);
     }
 
-    int comboItemImageText(nk_image img, const(char)* txt, int len, nk_flags align_ment)
+    int comboItemImageText(NKImage img, const(char)* txt, int len, NKFlags align_ment)
     {
         return nk_combo_item_image_text(&ctx, img, txt, len, align_ment);
     }
 
-    int comboItemSymbolLabel(nk_symbol_type type, const(char)* label, nk_flags align_ment)
+    int comboItemSymbolLabel(nk_symbol_type type, const(char)* label, NKFlags align_ment)
     {
         return nk_combo_item_symbol_label(&ctx, type, label, align_ment);
     }
 
-    int comboItemSymbolText(nk_symbol_type type, const(char)* txt, int len, nk_flags align_ment)
+    int comboItemSymbolText(nk_symbol_type type, const(char)* txt, int len, NKFlags align_ment)
     {
         return nk_combo_item_symbol_text(&ctx, type, txt, len, align_ment);
     }
@@ -1499,37 +1498,37 @@ class NuklearGUI : Owner, Drawable
         nk_combo_end(&ctx);
     }
 
-    int contextualBegin(nk_flags flags, nk_vec2 size, nk_rect trigger_bounds)
+    int contextualBegin(NKFlags flags, NKVec2 size, NKRect trigger_bounds)
     {
         return nk_contextual_begin(&ctx, flags, size, trigger_bounds);
     }
 
-    int contextualItemText(const(char)* txt, int len, nk_flags align_)
+    int contextualItemText(const(char)* txt, int len, NKFlags align_)
     {
         return nk_contextual_item_text(&ctx, txt, len, align_);
     }
 
-    int contextualItemLabel(const(char)* label, nk_flags align_)
+    int contextualItemLabel(const(char)* label, NKFlags align_)
     {
         return nk_contextual_item_label(&ctx, label, align_);
     }
 
-    int contextualItemImageLabel(nk_image img, const(char)* label, nk_flags align_ment)
+    int contextualItemImageLabel(NKImage img, const(char)* label, NKFlags align_ment)
     {
         return nk_contextual_item_image_label(&ctx, img, label, align_ment);
     }
 
-    int contextualItemImageText(nk_image img, const(char)* txt, int len, nk_flags align_ment)
+    int contextualItemImageText(NKImage img, const(char)* txt, int len, NKFlags align_ment)
     {
         return nk_contextual_item_image_text(&ctx, img, txt, len, align_ment);
     }
 
-    int contextualItemSymbolLabel(nk_symbol_type type, const(char)* label, nk_flags align_ment)
+    int contextualItemSymbolLabel(nk_symbol_type type, const(char)* label, NKFlags align_ment)
     {
         return nk_contextual_item_symbol_label(&ctx, type, label, align_ment);
     }
 
-    int contextualItemSymbolText(nk_symbol_type type, const(char)* txt, int len, nk_flags align_ment)
+    int contextualItemSymbolText(nk_symbol_type type, const(char)* txt, int len, NKFlags align_ment)
     {
         return nk_contextual_item_symbol_text(&ctx, type, txt, len, align_ment);
     }
@@ -1576,72 +1575,72 @@ class NuklearGUI : Owner, Drawable
         nk_menubar_end(&ctx);
     }
 
-    int menuBeginText(const(char)* title, int title_len, nk_flags align_, nk_vec2 size)
+    int menuBeginText(const(char)* title, int title_len, NKFlags align_, NKVec2 size)
     {
         return nk_menu_begin_text(&ctx, title, title_len, align_, size);
     }
 
-    int menuBeginLabel(const(char)* label, nk_flags align_, nk_vec2 size)
+    int menuBeginLabel(const(char)* label, NKFlags align_, NKVec2 size)
     {
         return nk_menu_begin_label(&ctx, label, align_, size);
     }
 
-    int menuBeginImage(const(char)* label, nk_image img, nk_vec2 size)
+    int menuBeginImage(const(char)* label, NKImage img, NKVec2 size)
     {
         return nk_menu_begin_image(&ctx, label, img, size);
     }
 
-    int menuBeginImageText(const(char)* txt, int len, nk_flags align_, nk_image img, nk_vec2 size)
+    int menuBeginImageText(const(char)* txt, int len, NKFlags align_, NKImage img, NKVec2 size)
     {
         return nk_menu_begin_image_text(&ctx, txt, len, align_, img, size);
     }
 
-    int menuBeginImageLabel(const(char)* label, nk_flags align_, nk_image img, nk_vec2 size)
+    int menuBeginImageLabel(const(char)* label, NKFlags align_, NKImage img, NKVec2 size)
     {
         return nk_menu_begin_image_label(&ctx, label, align_, img, size);
     }
 
-    int menuBeginSymbol(const(char)* label, nk_symbol_type type, nk_vec2 size)
+    int menuBeginSymbol(const(char)* label, nk_symbol_type type, NKVec2 size)
     {
         return nk_menu_begin_symbol(&ctx, label, type, size);
     }
 
-    int menuBeginSymbolText(const(char)* txt, int len, nk_flags align_, nk_symbol_type type, nk_vec2 size)
+    int menuBeginSymbolText(const(char)* txt, int len, NKFlags align_, nk_symbol_type type, NKVec2 size)
     {
         return nk_menu_begin_symbol_text(&ctx, txt, len, align_, type, size);
     }
 
-    int menuBeginSymbolLabel(const(char)* label, nk_flags align_, nk_symbol_type type, nk_vec2 size)
+    int menuBeginSymbolLabel(const(char)* label, NKFlags align_, nk_symbol_type type, NKVec2 size)
     {
         return nk_menu_begin_symbol_label(&ctx, label, align_, type, size);
     }
 
-    int menuItemText(const(char)* txt, int len, nk_flags align_)
+    int menuItemText(const(char)* txt, int len, NKFlags align_)
     {
         return nk_menu_item_text(&ctx, txt, len, align_);
     }
 
-    int menuItemLabel(const(char)* label, nk_flags align_ment)
+    int menuItemLabel(const(char)* label, NKFlags align_ment)
     {
         return nk_menu_item_label(&ctx, label, align_ment);
     }
 
-    int menuItemImageLabel(nk_image img, const(char)* label, nk_flags align_ment)
+    int menuItemImageLabel(NKImage img, const(char)* label, NKFlags align_ment)
     {
         return nk_menu_item_image_label(&ctx, img, label, align_ment);
     }
 
-    int menuItemImageText(nk_image img, const(char)* txt, int len, nk_flags align_ment)
+    int menuItemImageText(NKImage img, const(char)* txt, int len, NKFlags align_ment)
     {
         return nk_menu_item_image_text(&ctx, img, txt, len, align_ment);
     }
 
-    int menuItemSymbolText(nk_symbol_type type, const(char)* txt, int len, nk_flags align_ment)
+    int menuItemSymbolText(nk_symbol_type type, const(char)* txt, int len, NKFlags align_ment)
     {
         return nk_menu_item_symbol_text(&ctx, type, txt, len, align_ment);
     }
 
-    int menuItemSymbolLabel(nk_symbol_type type, const(char)* label, nk_flags align_ment)
+    int menuItemSymbolLabel(nk_symbol_type type, const(char)* label, NKFlags align_ment)
     {
         return nk_menu_item_symbol_label(&ctx, type, label, align_ment);
     }
@@ -1661,22 +1660,22 @@ class NuklearGUI : Owner, Drawable
         nk_style_default(&ctx);
     }
 
-    void styleFromTable(const(nk_color)* colors)
+    void styleFromTable(const(NKColor)* colors)
     {
         nk_style_from_table(&ctx, colors);
     }
 
-    void styleLoadCursor(nk_style_cursor cursor, const(nk_cursor)* c)
+    void styleLoadCursor(nk_style_cursor cursor, const(NKCursor)* c)
     {
         nk_style_load_cursor(&ctx, cursor, c);
     }
     
-    void styleLoadAllCursors(nk_cursor* cursor)
+    void styleLoadAllCursors(NKCursor* cursor)
     {
         nk_style_load_all_cursors(&ctx, cursor);
     }
 
-    void styleSetFont(const(nk_font)* font)
+    void styleSetFont(const(NKFont)* font)
     {
         nk_style_set_font(&ctx, &font.handle);
     }
@@ -1711,7 +1710,7 @@ class NuklearGUI : Owner, Drawable
         return nk_style_push_float(&ctx, address, value);
     }
 
-    int stylePushVec2(nk_vec2* address, nk_vec2 value)
+    int stylePushVec2(NKVec2* address, NKVec2 value)
     {
         return nk_style_push_vec2(&ctx, address, value);
     }
@@ -1721,12 +1720,12 @@ class NuklearGUI : Owner, Drawable
         return nk_style_push_style_item(&ctx, address, value);
     }
 
-    int stylePushFlags(nk_flags* address, nk_flags value)
+    int stylePushFlags(NKFlags* address, NKFlags value)
     {
         return nk_style_push_flags(&ctx, address, value);
     }
 
-    int stylePushColor(nk_color* address, nk_color value)
+    int stylePushColor(NKColor* address, NKColor value)
     {
         return nk_style_push_color(&ctx, address, value);
     }
@@ -1763,102 +1762,102 @@ class NuklearGUI : Owner, Drawable
 
     // Primitives
 
-    void strokeLine(float x0, float y0, float x1, float y1, float line_thickness, nk_color color)
+    void strokeLine(float x0, float y0, float x1, float y1, float line_thickness, NKColor color)
     {
         if(ctx.current)
             nk_stroke_line(&ctx.current.buffer, x0, y0, x1, y1, line_thickness, color);
     }
 
-    void strokeCurve(float ax, float ay, float ctrl0x, float ctrl0y, float ctrl1x, float ctrl1y, float bx, float by, float line_thickness, nk_color color)
+    void strokeCurve(float ax, float ay, float ctrl0x, float ctrl0y, float ctrl1x, float ctrl1y, float bx, float by, float line_thickness, NKColor color)
     {
         if(ctx.current)
             nk_stroke_curve(&ctx.current.buffer, ax, ay, ctrl0x, ctrl0y, ctrl1x, ctrl1y, bx, by, line_thickness, color);
     }
 
-    void strokeRect(nk_rect rect, float rounding, float line_thickness, nk_color color)
+    void strokeRect(NKRect rect, float rounding, float line_thickness, NKColor color)
     {
         if(ctx.current)
             nk_stroke_rect(&ctx.current.buffer, rect, rounding, line_thickness, color);
     }
 
-    void strokeCircle(nk_rect rect, float line_thickness, nk_color color)
+    void strokeCircle(NKRect rect, float line_thickness, NKColor color)
     {
         if(ctx.current)
             nk_stroke_circle(&ctx.current.buffer, rect, line_thickness, color);
     }
 
-    void strokeArc(float cx, float cy, float radius, float a_min, float a_max, float line_thickness, nk_color color)
+    void strokeArc(float cx, float cy, float radius, float a_min, float a_max, float line_thickness, NKColor color)
     {
         if(ctx.current)
             nk_stroke_arc(&ctx.current.buffer, cx, cy, radius, a_min, a_max, line_thickness, color);
     }
 
-    void strokeTriangle(float x0, float y0, float x1, float y1, float x2, float y2, float line_thichness, nk_color color)
+    void strokeTriangle(float x0, float y0, float x1, float y1, float x2, float y2, float line_thichness, NKColor color)
     {
         if(ctx.current)
             nk_stroke_triangle(&ctx.current.buffer, x0, y0, x1, y1, x2, y2, line_thichness, color);
     }
 
-    void strokePolyline(float* points, int point_count, float line_thickness, nk_color color)
+    void strokePolyline(float* points, int point_count, float line_thickness, NKColor color)
     {
         if(ctx.current)
             nk_stroke_polyline(&ctx.current.buffer, points, point_count, line_thickness, color);
     }
 
-    void strokePolygon(float* points, int point_count, float line_thickness, nk_color color)
+    void strokePolygon(float* points, int point_count, float line_thickness, NKColor color)
     {
         if(ctx.current)
             nk_stroke_polygon(&ctx.current.buffer, points, point_count, line_thickness, color);
     }
 
-    void fillRect(nk_rect rect, float rounding, nk_color color)
+    void fillRect(NKRect rect, float rounding, NKColor color)
     {
         if(ctx.current)
             nk_fill_rect(&ctx.current.buffer, rect, rounding, color);
     }
 
-    void fillRectMultiColor(nk_rect rect, nk_color left, nk_color top, nk_color right, nk_color bottom)
+    void fillRectMultiColor(NKRect rect, NKColor left, NKColor top, NKColor right, NKColor bottom)
     {
         if(ctx.current)
             nk_fill_rect_multi_color(&ctx.current.buffer, rect, left, top, right, bottom);
     }
 
-    void fillCircle(nk_rect rect, nk_color color)
+    void fillCircle(NKRect rect, NKColor color)
     {
         if(ctx.current)
             nk_fill_circle(&ctx.current.buffer, rect, color);
     }
 
-    void fillArc(float cx, float cy, float radius, float a_min, float a_max, nk_color color)
+    void fillArc(float cx, float cy, float radius, float a_min, float a_max, NKColor color)
     {
         if(ctx.current)
             nk_fill_arc(&ctx.current.buffer, cx, cy, radius, a_min, a_max, color);
     }
 
-    void fillTriangle(float x0, float y0, float x1, float y1, float x2, float y2, nk_color color)
+    void fillTriangle(float x0, float y0, float x1, float y1, float x2, float y2, NKColor color)
     {
         if(ctx.current)
             nk_fill_triangle(&ctx.current.buffer, x0, y0, x1, y1, x2, y2, color);
     }
 
-    void fillPolygon(float* points, int point_count, nk_color color)
+    void fillPolygon(float* points, int point_count, NKColor color)
     {
         if(ctx.current)
             nk_fill_polygon(&ctx.current.buffer, points, point_count, color);
     }
 
-    void drawImage(nk_rect rect, const(nk_image)* image, nk_color color)
+    void drawImage(NKRect rect, const(NKImage)* image, NKColor color)
     {
         if(ctx.current)
             nk_draw_image(&ctx.current.buffer, rect, image, color);
     }
 
-    void drawText(nk_rect rect, const(char)* txt, int len, const(nk_font)* font, nk_color bg, nk_color fg)
+    void drawText(NKRect rect, const(char)* txt, int len, const(NKFont)* font, NKColor bg, NKColor fg)
     {
         drawText(rect, txt, len, &font.handle, bg, fg);
     }
 
-    void drawText(nk_rect rect, const(char)* txt, int len, const(nk_user_font)* font, nk_color bg, nk_color fg)
+    void drawText(NKRect rect, const(char)* txt, int len, const(nk_user_font)* font, NKColor bg, NKColor fg)
     {
         if(!font)
             font = &atlas.default_font.handle;
@@ -1866,7 +1865,7 @@ class NuklearGUI : Owner, Drawable
             nk_draw_text(&ctx.current.buffer, rect, txt, len, font, bg, fg);
     }
 
-    void pushScissor(nk_rect rect)
+    void pushScissor(NKRect rect)
     {
         if(ctx.current)
             nk_push_scissor(&ctx.current.buffer, rect);

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -445,6 +445,31 @@ class NuklearGUI : Owner, Drawable
         nk_end(&ctx);
     }
 
+    nk_style_window oldWindowStyle;
+
+    int canvasBegin(const(char)* title, nk_rect bounds, nk_color background)
+    {
+        oldWindowStyle = ctx.style.window;
+
+        ctx.style.window.spacing = nk_vec2(0, 0);
+        ctx.style.window.padding = nk_vec2(0, 0);
+        ctx.style.window.fixed_background = nk_style_item_color(background);
+
+        nk_begin(&ctx, "Window", bounds, NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND | NK_WINDOW_NO_INPUT);
+
+        nk_rect totalSpace = nk_window_get_content_region(&ctx);
+        nk_layout_row_dynamic(&ctx, totalSpace.h, 1);
+        nk_widget(&totalSpace, &ctx);
+
+        return 1;
+    }
+
+    void canvasEnd()
+    {
+        nk_end(&ctx);
+        ctx.style.window = oldWindowStyle;
+    }
+
     nk_window* windowFind(const(char)* name)
     {
         return nk_window_find(&ctx, name);

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -37,6 +37,7 @@ import dagon.core.ownership;
 import dagon.core.event;
 import dagon.core.keycodes;
 import dagon.graphics.shaderloader;
+import dagon.graphics.texture;
 import dagon.resource.fontasset;
 
 alias nk_color NKColor;
@@ -54,6 +55,17 @@ alias nk_rune NKRune;
 alias nk_handle NKHandle;
 alias nk_window NKWindow;
 alias nk_panel NKPanel;
+
+NKImage toNKImage(Texture texture)
+{
+    NKImage img;
+    img.handle.id = cast(int)texture.tex;
+    img.w = cast(short)texture.width;
+    img.h = cast(short)texture.height;
+    img.region[2] = cast(short)texture.width;
+    img.region[3] = cast(short)texture.height;
+    return img;
+}
 
 private extern(C) void clipboardPaste(nk_handle usr, nk_text_edit* edit)
 {

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -1261,18 +1261,25 @@ class NuklearGUI : Owner, Drawable
         return nk_propertyd(&ctx, name, min, val, max, step, inc_per_pixel);
     }
 
+    alias nk_filter_default filterDefault;
+    alias nk_filter_ascii filterAscii;
+    alias nk_filter_float filterFloat;
+    alias nk_filter_decimal filterDecimal;
+    alias nk_filter_hex filterHex;
+    alias nk_filter_oct filterOct;
+    alias nk_filter_binary filterBinary;
 
-    nk_flags editString(nk_flags flags, char* buffer, int* len, int max, nk_plugin_filter filter)
+    nk_flags editString(nk_flags flags, char* buffer, int* len, int max, nk_plugin_filter filter = filterDefault)
     {
         return nk_edit_string(&ctx, flags, buffer, len, max, filter);
     }
 
-    nk_flags editStringZeroTerminated(nk_flags flags, char* buffer, int max, nk_plugin_filter filter)
+    nk_flags editStringZeroTerminated(nk_flags flags, char* buffer, int max, nk_plugin_filter filter = filterDefault)
     {
         return nk_edit_string_zero_terminated(&ctx, flags, buffer, max, filter);
     }
 
-    nk_flags editBuffer(nk_flags flags, nk_text_edit* edit, nk_plugin_filter filter)
+    nk_flags editBuffer(nk_flags flags, nk_text_edit* edit, nk_plugin_filter filter = filterDefault)
     {
         return nk_edit_buffer(&ctx, flags, edit, filter);
     }

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -27,16 +27,8 @@ DEALINGS IN THE SOFTWARE.
 
 module dagon.ui.nuklear;
 
-import core.stdc.stdio;
 import core.stdc.stdarg;
-import std.stdio;
 
-import dlib.core.memory;
-import dlib.core.stream;
-import dlib.container.dict;
-import dlib.container.queue;
-import dlib.text.utf8;
-import dlib.math.vector;
 import dlib.image.color;
 
 import dagon.core.interfaces;
@@ -44,10 +36,7 @@ import dagon.core.libs;
 import dagon.core.ownership;
 import dagon.core.event;
 import dagon.core.keycodes;
-import dagon.ui.font;
-import dagon.graphics.rc;
 import dagon.graphics.shaderloader;
-import dagon.graphics.texture;
 import dagon.resource.fontasset;
 
 private extern(C) void clipboardPaste(nk_handle usr, nk_text_edit* edit)

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -1882,4 +1882,56 @@ class NuklearGUI : Owner, Drawable
         if(ctx.current)
             nk_push_scissor(&ctx.current.buffer, rect);
     }
+
+    // Colors
+
+    NKColor rgb(int r, int g, int b)
+    {
+        return nk_rgb(r, g, b);
+    }
+
+    NKColor rgb(float r, float g, float b)
+    {
+        return nk_rgb_f(r, g, b);
+    }
+
+    NKColor rgb(char* hex)
+    {
+        return nk_rgb_hex(hex);
+    }
+
+    NKColor rgba(int r, int g, int b, int a)
+    {
+        return nk_rgba(r, g, b, a);
+    }
+
+    NKColor rgba(float r, float g, float b, float a)
+    {
+        return nk_rgba_f(r, g, b, a);
+    }
+
+    NKColor rgba(char* hex)
+    {
+        return nk_rgba_hex(hex);
+    }
+
+    NKColor hsv(int h, int s, int v)
+    {
+        return nk_hsv(h, s, v);
+    }
+
+    NKColor hsv(float h, float s, float v)
+    {
+        return nk_hsv_f(h, s, v);
+    }
+
+    NKColor hsva(int h, int s, int v, int a)
+    {
+        return nk_hsva(h, s, v, a);
+    }
+
+    NKColor hsva(float h, float s, float v, float a)
+    {
+        return nk_hsva_f(h, s, v, a);
+    }
 }

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -28,6 +28,7 @@ DEALINGS IN THE SOFTWARE.
 module dagon.ui.nuklear;
 
 import core.stdc.stdio;
+import core.stdc.stdarg;
 import std.stdio;
 
 import dlib.core.memory;
@@ -228,6 +229,8 @@ class NuklearGUI : Owner, Drawable
 
     override void update(double dt)
     {
+        nk_clear(&ctx);
+
         nk_input_begin(&ctx);
         nk_input_motion(&ctx, eventManager.mouseX, eventManager.mouseY);
 
@@ -331,7 +334,6 @@ class NuklearGUI : Owner, Drawable
                             glDrawElements(GL_TRIANGLES, cmd.elem_count, GL_UNSIGNED_INT, offset);
                             offset += cmd.elem_count;
                         });
-        nk_clear(&ctx);
 
         glDisable(GL_BLEND);
         glDisable(GL_SCISSOR_TEST);
@@ -836,46 +838,34 @@ class NuklearGUI : Owner, Drawable
         nk_image_color(&ctx, img, color);
     }
 
-    /*void labelf(nk_flags, const(char)*, ...)
+    void labelf(nk_flags align_, const(char)* format, ...)
     {
-    nk_labelf(&ctx);
+        va_list args;
+        va_start(args, format);
+        nk_labelfv(&ctx, align_, format, args);
     }
 
-    void labelfColored(nk_flags, nk_color, const(char)*, ...)
+    void labelfColored(nk_flags align_, nk_color color, const(char)* format, ...)
     {
-    nk_labelf_colored(&ctx);
+        va_list args;
+        va_start(args, format);
+        nk_labelf_colored(&ctx, align_, color, format, args);
     }
 
-    void labelfWrap(const(char)*, ...)
+    void labelfWrap(const(char)* format, ...)
     {
-    nk_labelf_wrap(&ctx);
+        va_list args;
+        va_start(args, format);
+        nk_labelf_wrap(&ctx, format, args);
     }
 
-    void labelfColoredWrap(nk_color, const(char)*, ...)
+    void labelfColoredWrap(nk_color color, const(char)* format, ...)
     {
-    nk_labelf_colored_wrap(&ctx);
+        va_list args;
+        va_start(args, format);
+        nk_labelf_colored_wrap(&ctx, color, format, args);
     }
 
-    void labelfv(nk_flags, const(char)*, va_list)
-    {
-    nk_labelfv(&ctx);
-    }
-
-    void labelfvColored(nk_flags, nk_color, const(char)*, va_list)
-    {
-    nk_labelfv_colored(&ctx);
-    }
-
-    void labelfvWrap(const(char)*, va_list)
-    {
-    nk_labelfv_wrap(&ctx);
-    }
-
-    void labelfvColoredWrap(nk_color, const(char)*, va_list)
-    {
-    nk_labelfv_colored_wrap(&ctx);
-    }
-    */
     void valueBool(const(char)* prefix, int value)
     {
         nk_value_bool(&ctx, prefix, value);
@@ -1497,15 +1487,12 @@ class NuklearGUI : Owner, Drawable
         nk_tooltip(&ctx, txt);
     }
 
-    /*void tooltipf(const(char)*, ...)
+    void tooltipf(const(char)* format, ...)
     {
-    nk_tooltipf(&ctx);
+        va_list args;
+        va_start(args, format);
+        nk_tooltipfv(&ctx, format, args);
     }
-
-    void tooltipfv(const(char)*, va_list)
-    {
-    nk_tooltipfv(&ctx);
-    }*/
     
     int tooltipBegin(float width)
     {

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -263,7 +263,6 @@ class NuklearGUI : Owner, Drawable
         }
 
         nk_input_end(&ctx);
-        //nk_style_set_font(&ctx, &atlas.fonts.next.next.handle);
     }
 
     override void render(RenderingContext* rc)
@@ -345,9 +344,16 @@ class NuklearGUI : Owner, Drawable
         glDisable(GL_SCISSOR_TEST);
     }
 
-    nk_font* addFont(FontAsset font, float height)
+    static const(nk_rune[]) fontDefaultGlyphRanges = [ 0x0020, 0x00FF, 0 ];
+    static const(nk_rune[]) fontChineseGlyphRanges = [ 0x0020, 0x00FF, 0x3000, 0x30FF, 0x31F0, 0x31FF, 0xFF00, 0xFFEF, 0x4E00, 0x9FAF, 0 ];
+    static const(nk_rune[]) fontCyrillicGlyphRanges = [ 0x0020, 0x00FF,  0x0400, 0x052F, 0x2DE0, 0x2DFF, 0xA640, 0xA69F, 0 ];
+    static const(nk_rune[]) fontKoreanGlyphRanges = [ 0x0020, 0x00FF, 0x3131, 0x3163,  0xAC00, 0xD79D, 0 ];
+
+    nk_font* addFont(FontAsset font, float height = 13, const(nk_rune[]) range = fontDefaultGlyphRanges)
     {
-        return lastFont = nk_font_atlas_add_from_memory(&atlas, font.buffer.ptr, font.buffer.length, height, null);
+        nk_font_config cfg = nk_font_config_(0);
+        cfg.range = range.ptr;
+        return lastFont = nk_font_atlas_add_from_memory(&atlas, font.buffer.ptr, font.buffer.length, height, &cfg);
     }
 
     void inputKey(nk_keys key, int down)
@@ -1650,6 +1656,11 @@ class NuklearGUI : Owner, Drawable
         nk_style_load_all_cursors(&ctx, cursor);
     }
 
+    void styleSetFont(const(nk_font)* font)
+    {
+        nk_style_set_font(&ctx, &font.handle);
+    }
+
     void styleSetFont(const(nk_user_font)* font)
     {
         nk_style_set_font(&ctx, font);
@@ -1820,6 +1831,11 @@ class NuklearGUI : Owner, Drawable
     {
         if(ctx.current)
             nk_draw_image(&ctx.current.buffer, rect, image, color);
+    }
+
+    void drawText(nk_rect rect, const(char)* txt, int len, const(nk_font)* font, nk_color bg, nk_color fg)
+    {
+        drawText(rect, txt, len, &font.handle, bg, fg);
     }
 
     void drawText(nk_rect rect, const(char)* txt, int len, const(nk_user_font)* font, nk_color bg, nk_color fg)

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -1693,4 +1693,104 @@ class NuklearGUI : Owner, Drawable
     {
         return nk_style_pop_color(&ctx);
     }
+
+    // Primitives
+
+    void strokeLine(float x0, float y0, float x1, float y1, float line_thickness, nk_color color)
+    {
+        if(ctx.current)
+            nk_stroke_line(&ctx.current.buffer, x0, y0, x1, y1, line_thickness, color);
+    }
+
+    void strokeCurve(float ax, float ay, float ctrl0x, float ctrl0y, float ctrl1x, float ctrl1y, float bx, float by, float line_thickness, nk_color color)
+    {
+        if(ctx.current)
+            nk_stroke_curve(&ctx.current.buffer, ax, ay, ctrl0x, ctrl0y, ctrl1x, ctrl1y, bx, by, line_thickness, color);
+    }
+
+    void strokeRect(nk_rect rect, float rounding, float line_thickness, nk_color color)
+    {
+        if(ctx.current)
+            nk_stroke_rect(&ctx.current.buffer, rect, rounding, line_thickness, color);
+    }
+
+    void strokeCircle(nk_rect rect, float line_thickness, nk_color color)
+    {
+        if(ctx.current)
+            nk_stroke_circle(&ctx.current.buffer, rect, line_thickness, color);
+    }
+
+    void strokeArc(float cx, float cy, float radius, float a_min, float a_max, float line_thickness, nk_color color)
+    {
+        if(ctx.current)
+            nk_stroke_arc(&ctx.current.buffer, cx, cy, radius, a_min, a_max, line_thickness, color);
+    }
+
+    void strokeTriangle(float x0, float y0, float x1, float y1, float x2, float y2, float line_thichness, nk_color color)
+    {
+        if(ctx.current)
+            nk_stroke_triangle(&ctx.current.buffer, x0, y0, x1, y1, x2, y2, line_thichness, color);
+    }
+
+    void strokePolyline(float* points, int point_count, float line_thickness, nk_color color)
+    {
+        if(ctx.current)
+            nk_stroke_polyline(&ctx.current.buffer, points, point_count, line_thickness, color);
+    }
+
+    void strokePolygon(float* points, int point_count, float line_thickness, nk_color color)
+    {
+        if(ctx.current)
+            nk_stroke_polygon(&ctx.current.buffer, points, point_count, line_thickness, color);
+    }
+
+    void fillRect(nk_rect rect, float rounding, nk_color color)
+    {
+        if(ctx.current)
+            nk_fill_rect(&ctx.current.buffer, rect, rounding, color);
+    }
+
+    void fillRectMultiColor(nk_rect rect, nk_color left, nk_color top, nk_color right, nk_color bottom)
+    {
+        if(ctx.current)
+            nk_fill_rect_multi_color(&ctx.current.buffer, rect, left, top, right, bottom);
+    }
+
+    void fillCircle(nk_rect rect, nk_color color)
+    {
+        if(ctx.current)
+            nk_fill_circle(&ctx.current.buffer, rect, color);
+    }
+
+    void fillArc(float cx, float cy, float radius, float a_min, float a_max, nk_color color)
+    {
+        if(ctx.current)
+            nk_fill_arc(&ctx.current.buffer, cx, cy, radius, a_min, a_max, color);
+    }
+
+    void fillTriangle(float x0, float y0, float x1, float y1, float x2, float y2, nk_color color)
+    {
+        if(ctx.current)
+            nk_fill_triangle(&ctx.current.buffer, x0, y0, x1, y1, x2, y2, color);
+    }
+
+    void fillPolygon(float* points, int point_count, nk_color color)
+    {
+        if(ctx.current)
+            nk_fill_polygon(&ctx.current.buffer, points, point_count, color);
+    }
+
+    void drawImage(nk_rect rect, const(nk_image)* image, nk_color color)
+    {
+        if(ctx.current)
+            nk_draw_image(&ctx.current.buffer, rect, image, color);
+    }
+
+    void drawText(nk_rect rect, const(char)* txt, int len, const(nk_user_font)* font, nk_color bg, nk_color fg)
+    {
+        if(!font)
+            font = &atlas.default_font.handle;
+        if(ctx.current)
+            nk_draw_text(&ctx.current.buffer, rect, txt, len, font, bg, fg);
+    }
 }

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -444,7 +444,7 @@ class NuklearGUI : Owner, Drawable
         ctx.style.window.padding = nk_vec2(0, 0);
         ctx.style.window.fixed_background = nk_style_item_color(background);
 
-        nk_begin(&ctx, "Window", bounds, NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND | NK_WINDOW_NO_INPUT);
+        nk_begin(&ctx, title, bounds, NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND | NK_WINDOW_NO_INPUT);
 
         nk_rect totalSpace = nk_window_get_content_region(&ctx);
         nk_layout_row_dynamic(&ctx, totalSpace.h, 1);

--- a/src/dagon/ui/nuklear.d
+++ b/src/dagon/ui/nuklear.d
@@ -156,11 +156,8 @@ class NuklearGUI : Owner, Drawable
         nk_font_atlas_clear(&atlas);
         nk_free(&ctx);
         nk_buffer_free(&cmds);
-        glDetachShader(shaderProgram, vertexShader);
-        glDetachShader(shaderProgram, fragmentShader);
-        glDeleteShader(vertexShader);
-        glDeleteShader(fragmentShader);
-        glDeleteProgram(shaderProgram);
+
+        glDeleteProgram(shaderProgram); 
         glDeleteTextures(1, &fontTexture);
         glDeleteBuffers(1, &vbo);
         glDeleteBuffers(1, &ebo);


### PR DESCRIPTION
Features:
- Fonts loading with UTF ranges support

- 2D primitives drawing

- Canvas widget for primitives

- Colors creation from rgb, rgba, hsv, hsva

Fixes:

- TextInput utf8 decoder

- Textures mipmap generation at creation so GUI can draw textures that are not part of any drawable model 

API changes:
- NuklearGUI constructor now takes eventManager and not pointer to it

- Change structures names from gui.Rect to NKRect, gui.Color to NKColor, etc

- Change toNuklearImage to toNKImage

GUI is now powerful enough to create custom widgets or even 2D games thanks to primitives drawing.
As prove of concept I create 2D sokoban clone [Dagoban](https://github.com/Timu5/dagoban) with level editor!(see below)

![utf8_shapes](https://user-images.githubusercontent.com/5563731/52436386-74c63d80-2b14-11e9-9e8b-a16040e26d23.png)
![dagoban](https://user-images.githubusercontent.com/5563731/52436397-7db70f00-2b14-11e9-97ad-2d0fd72e2b9e.gif)

