### PR TITLE
Remove error check in callback

### DIFF
--- a/src/dagon/core/application.d
+++ b/src/dagon/core/application.d
@@ -74,11 +74,6 @@ extern(System) nothrow void messageCallback(
     string empty = "";
     if (severity != GL_DEBUG_SEVERITY_NOTIFICATION)
         printf(msg.ptr, (type == GL_DEBUG_TYPE_ERROR ? err.ptr : empty.ptr), type, severity, message);
-    if (type == GL_DEBUG_TYPE_ERROR)
-    {
-        Application app = cast(Application)userParam;
-        app.eventManager.running = false;
-    }
 }
 
 /++


### PR DESCRIPTION
The callback does not need to stop the application since checkGLError will do that. Making it so that checkGLError is responsible for closing the application also allows library users to disable this behavior.

This also fixes a segfault that occurred on any OpenGL error, since userParam is currently always null.