### PR TITLE
Set swap interval after creating the GL context

### DIFF
--- a/src/dagon/core/application.d
+++ b/src/dagon/core/application.d
@@ -161,12 +161,13 @@ class Application: EventListener
         if (window is null)
             exitWithError("Error: failed to create window: " ~ to!string(SDL_GetError()));
 
-        SDL_GL_SetSwapInterval(1);
 
         glcontext = SDL_GL_CreateContext(window);
         if (glcontext is null)
             exitWithError("Error: failed to create OpenGL context: " ~ to!string(SDL_GetError()));
 
+        SDL_GL_SetSwapInterval(1);
+        
         SDL_GL_MakeCurrent(window, glcontext);
 
         GLSupport glsup = loadOpenGL();


### PR DESCRIPTION
Otherwise it has no effect, now when VSYNC enable it properly works and CPU usage isn't at 100% anymore