### PR TITLE
Remove warnings

### DIFF
--- a/src/dagon/graphics/texture.d
+++ b/src/dagon/graphics/texture.d
@@ -525,7 +525,7 @@ class Texture: Owner
                 if (generateMipmaps)
                 {
                     glGenerateMipmap(GL_TEXTURE_1D);
-                    mipLevels = 1 + cast(uint)floor(log2(w));
+                    mipLevels = 1 + cast(uint)floor(log2(cast(float)w));
                 }
                 else
                     mipLevels = 1;
@@ -580,7 +580,7 @@ class Texture: Owner
                 if (generateMipmaps)
                 {
                     glGenerateMipmap(GL_TEXTURE_2D);
-                    mipLevels = 1 + cast(uint)floor(log2(max(w, h)));
+                    mipLevels = 1 + cast(uint)floor(log2(cast(float)max(w, h)));
                 }
                 else
                     mipLevels = 1;
@@ -650,7 +650,7 @@ class Texture: Owner
                 if (generateMipmaps)
                 {
                     glGenerateMipmap(GL_TEXTURE_3D);
-                    mipLevels = 1 + cast(uint)floor(log2(max3(w, h, d)));
+                    mipLevels = 1 + cast(uint)floor(log2(cast(float)max3(w, h, d)));
                 }
                 else
                     mipLevels = 1;
@@ -722,7 +722,7 @@ class Texture: Owner
             if (generateMipmaps)
             {
                 glGenerateMipmap(GL_TEXTURE_CUBE_MAP);
-                mipLevels = 1 + cast(uint)floor(log2(resolution));
+                mipLevels = 1 + cast(uint)floor(log2(cast(float)resolution));
             }
             else
                 mipLevels = 1;
@@ -741,7 +741,7 @@ class Texture: Owner
         {
             bind();
             glGenerateMipmap(format.target);
-            mipLevels = 1 + cast(uint)floor(log2(max(size.width, size.height)));
+            mipLevels = 1 + cast(uint)floor(log2(cast(float)max(size.width, size.height)));
             unbind();
             useMipmapFiltering(true);
         }


### PR DESCRIPTION
Description:
Removed warnings of deprecated method call like below:

src/dagon/graphics/texture.d:528:57: warning: function ‘std.math.exponential.log2’ is deprecated - std.math.exponential.log2 called with argument types (uint) matches both log2(real), log2(double), and log2(float). Cast argument to floating point type instead. [-Wdeprecated]

Fix:
Expanded log2 calls to use log2(float) method explicitly.



