### PR TITLE
Updated nuklear to work on GNU compiler.

### DIFF
--- a/extensions/nuklear/src/dagon/ext/nuklear.d
+++ b/extensions/nuklear/src/dagon/ext/nuklear.d
@@ -1093,21 +1093,33 @@ class NuklearGUI: Owner, Updateable, Drawable
     {
         va_list args;
         va_start(args, format);
-        nk_labelf_colored(&ctx, align_, color, format, args);
+        version(GNU) {
+	        nk_labelf_colored(&ctx, align_, color, format, args.ptr);
+        } else {
+        	nk_labelf_colored(&ctx, align_, color, format, args);
+        }
     }
 
     void labelfWrap(const(char)* format, ...)
     {
         va_list args;
         va_start(args, format);
-        nk_labelf_wrap(&ctx, format, args);
+        version(GNU) {
+	        nk_labelf_wrap(&ctx, format, args.ptr);
+        } else {
+        	nk_labelf_wrap(&ctx, format, args);
+        }
     }
 
     void labelfColoredWrap(NKColor color, const(char)* format, ...)
     {
         va_list args;
         va_start(args, format);
-        nk_labelf_colored_wrap(&ctx, color, format, args);
+        version (GNU) {
+	        nk_labelf_colored_wrap(&ctx, color, format, args.ptr);
+        } else {
+        	nk_labelf_colored_wrap(&ctx, color, format, args);
+        }
     }
 
     void valueBool(const(char)* prefix, int value)


### PR DESCRIPTION
On GNU GDC compiler impossible to compile nuklear extension due to small problem:

While for DMD & LDC2 this is not an issue but in GDC
Variadic static array args cannot be passed to extern(C) method as value. Need to be converted into a pointer.

```log
~/dagon/extensions/nuklear$ dub build --compiler=gdc
    Starting Performing "debug" build using gdc for x86_64.
    Building nuklear ~master: building configuration [library]
src/dagon/ext/nuklear.d:1096:56: error: cannot pass static arrays to ‘extern(C)’ vararg functions
 1096 |         nk_labelf_colored(&ctx, align_, color, format, args);
      |                                                        ^
src/dagon/ext/nuklear.d:1103:38: error: cannot pass static arrays to ‘extern(C)’ vararg functions
 1103 |         nk_labelf_wrap(&ctx, format, args);
      |                                      ^
src/dagon/ext/nuklear.d:1110:53: error: cannot pass static arrays to ‘extern(C)’ vararg functions
 1110 |         nk_labelf_colored_wrap(&ctx, color, format, args);
      |                                                     ^
Error gdc failed with exit code 1.
```
